### PR TITLE
Add mobile hook test via vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -82,6 +83,8 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^14.0.0"
   }
 }

--- a/src/hooks/__tests__/use-mobile.test.tsx
+++ b/src/hooks/__tests__/use-mobile.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useIsMobile } from '../use-mobile'
+
+/**
+ * Helper to mock matchMedia and capture the change listener
+ */
+function setupMatchMedia() {
+  let listener: ((e: MediaQueryListEvent) => void) | null = null
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => {
+      return {
+        media: query,
+        matches: window.innerWidth < 768,
+        addEventListener: (_event: string, cb: (e: MediaQueryListEvent) => void) => {
+          listener = cb
+        },
+        removeEventListener: vi.fn(),
+        dispatchEvent: (e: MediaQueryListEvent) => {
+          if (listener) listener(e)
+          return true
+        },
+      }
+    }),
+  })
+  return () => {
+    if (listener) {
+      listener(new Event('change') as MediaQueryListEvent)
+    }
+  }
+}
+
+describe('useIsMobile', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('detects initial mobile width', async () => {
+    window.innerWidth = 500
+    const trigger = setupMatchMedia()
+    const { result } = renderHook(() => useIsMobile())
+    // trigger initial effect
+    act(() => {
+      trigger()
+    })
+    await waitFor(() => expect(result.current).toBe(true))
+  })
+
+  it('updates when viewport changes', async () => {
+    window.innerWidth = 900
+    const trigger = setupMatchMedia()
+    const { result } = renderHook(() => useIsMobile())
+    act(() => {
+      trigger()
+    })
+    await waitFor(() => expect(result.current).toBe(false))
+
+    act(() => {
+      window.innerWidth = 600
+      trigger()
+    })
+    await waitFor(() => expect(result.current).toBe(true))
+  })
+})

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"],
+    "module": "ESNext"
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,9 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    tsconfig: "tsconfig.vitest.json",
+  },
 }));


### PR DESCRIPTION
## Summary
- add vitest config and test setup
- create `useIsMobile` tests
- expose `test` script and test deps

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427088588c83228a11554ae8a6e8b7